### PR TITLE
Enable Next.js static export with normalized basePath and align GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_BASE_PATH: ${{ vars.NEXT_PUBLIC_BASE_PATH }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Upload artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ""
+const basePath = rawBasePath
+  ? `/${rawBasePath.replace(/^\\/+|\\/+$/g, "")}`
+  : ""
+
 const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
@@ -9,6 +14,10 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  output: "export",
+  trailingSlash: true,
+  basePath,
+  assetPrefix: basePath ? `${basePath}/` : undefined,
 }
 
 export default nextConfig


### PR DESCRIPTION
### Motivation
- Prepare the Next.js app to be served as a static export on GitHub Pages and ensure assets and routes resolve correctly by normalizing the public base path.
- Align the GitHub Pages workflow with a known-working reference to control triggers, concurrency, artifact upload, and use of `NEXT_PUBLIC_BASE_PATH` so builds and deployments behave predictably.

### Description
- Normalize `NEXT_PUBLIC_BASE_PATH` in `next.config.mjs` by computing `rawBasePath` and `basePath`, and enable static export with `output: "export"`, `trailingSlash: true`, `basePath`, and `assetPrefix` set appropriately.
- Replace the Pages workflow at `.github/workflows/pages.yml` with a version that triggers on `push` (all branches), `pull_request` to `main`, and `workflow_dispatch`, sets `NEXT_PUBLIC_BASE_PATH` from `vars`, uses Node 20 and `pnpm/action-setup@v4`, and runs `pnpm install --frozen-lockfile` and `pnpm run build`.
- Only upload the Pages artifact from `main` with `actions/upload-pages-artifact@v3` (path `./out`) and only run the deploy job on `main` using `actions/deploy-pages@v4`, and enable `cancel-in-progress: true` for the `pages` concurrency group.
- Remove the fallback behavior that automatically used the repository name for `NEXT_PUBLIC_BASE_PATH`, and remove the explicit `touch out/.nojekyll` step since the artifact upload handles the output directory.

### Testing
- No automated tests were executed for these changes (CI workflow was not run as part of this change set).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697166d375e88322b0ceabdb4767201a)